### PR TITLE
feat: refactor chat store and hooks to connect with cap information

### DIFF
--- a/src/features/ai-chat/hooks/use-chat-session.ts
+++ b/src/features/ai-chat/hooks/use-chat-session.ts
@@ -5,7 +5,7 @@ import { type ChatSession, ChatStateStore } from '@/features/ai-chat/stores';
 export const useChatSession = (sessionId: string) => {
   const store = ChatStateStore();
 
-  const session = store.getSession(sessionId);
+  const session = store.readSession(sessionId);
 
   const updateMessages = useCallback(
     (messages: Message[]) => {
@@ -16,78 +16,31 @@ export const useChatSession = (sessionId: string) => {
 
   const updateSingleMessage = useCallback(
     (messageId: string, updates: Partial<Message>) => {
-      const currentSession = store.getSession(sessionId);
-      if (!currentSession) return;
-
-      const updatedMessages = currentSession.messages.map((msg) =>
-        msg.id === messageId ? { ...msg, ...updates } : msg,
-      );
-
-      const updatedSession: ChatSession = {
-        ...currentSession,
-        messages: updatedMessages,
-        updatedAt: Date.now(),
-      };
-
-      store.updateSession(sessionId, updatedSession);
+      store.updateSingleMessage(sessionId, messageId, updates);
     },
-    [sessionId, store],
+    [sessionId],
   );
 
   const deleteMessage = useCallback(
     (messageId: string) => {
-      const currentSession = store.getSession(sessionId);
-      if (!currentSession) return;
-
-      const updatedMessages = currentSession.messages.filter(
-        (msg) => msg.id !== messageId,
-      );
-
-      const updatedSession: ChatSession = {
-        ...currentSession,
-        messages: updatedMessages,
-        updatedAt: Date.now(),
-      };
-
-      store.updateSession(sessionId, updatedSession);
+      store.deleteMessage(sessionId, messageId);
     },
-    [sessionId, store],
+    [sessionId],
   );
 
   const deleteMessagesAfterTimestamp = useCallback(
     (timestamp: number) => {
-      const currentSession = store.getSession(sessionId);
-      if (!currentSession) return;
-
-      const updatedMessages = currentSession.messages.filter((msg) => {
-        const messageTime = msg.createdAt
-          ? new Date(msg.createdAt).getTime()
-          : 0;
-        return messageTime < timestamp;
-      });
-
-      const updatedSession: ChatSession = {
-        ...currentSession,
-        messages: updatedMessages,
-        updatedAt: Date.now(),
-      };
-
-      store.updateSession(sessionId, updatedSession);
+      store.deleteMessagesAfterTimestamp(sessionId, timestamp);
     },
-    [sessionId, store],
+    [sessionId],
   );
-
-  const updateTitle = useCallback(async () => {
-    await store.updateTitle(sessionId);
-  }, [sessionId]);
 
   return {
     session,
-    messages: store.getMessages(sessionId),
+    messages: store.readMessages(sessionId),
     updateMessages,
     updateSingleMessage,
     deleteMessage,
     deleteMessagesAfterTimestamp,
-    updateTitle,
   };
 };

--- a/src/features/ai-chat/hooks/use-chat-sessions.ts
+++ b/src/features/ai-chat/hooks/use-chat-sessions.ts
@@ -5,6 +5,10 @@ import type { ChatSession } from '@/features/ai-chat/types';
 export const useChatSessions = () => {
   const store = ChatStateStore();
 
+  const createSession = useCallback((session?: Partial<ChatSession>) => {
+    return store.createSession(session);
+  }, []);
+
   const deleteSession = useCallback((id: string) => {
     store.deleteSession(id);
   }, []);
@@ -29,6 +33,7 @@ export const useChatSessions = () => {
   return {
     sessions: getSortedSessions(),
     sessionsMap: store.sessions,
+    createSession,
     deleteSession,
     updateSession,
     clearAllSessions,

--- a/src/features/ai-chat/types/index.ts
+++ b/src/features/ai-chat/types/index.ts
@@ -7,6 +7,8 @@ export interface ChatSession {
   createdAt: number;
   updatedAt: number;
   messages: Message[];
+  capId?: string;
+  capVersion?: string;
 }
 
 // stream ID management interface


### PR DESCRIPTION
This PR implements the refactor requested in issue #34 to connect chat sessions with Cap information and improve the store/hooks architecture.

## Changes Made:
- Add capId and capVersion fields to ChatSession type
- Refactor chat store with proper CRUD naming conventions
- Move title generation logic from store to handleAIRequest function
- Store current cap information in chat sessions via handleAIRequest
- Update hooks to use new store methods (createSession, readSession, etc.)
- Remove unused updateTitle method from hooks and store

This refactor improves the architecture by:
1. Connecting chat sessions with cap metadata
2. Following proper CRUD naming patterns
3. Moving service logic to appropriate layer
4. Simplifying hook implementations

Resolves #34

Generated with [Claude Code](https://claude.ai/code)